### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -172,6 +172,9 @@ export function setValueAtPath(target: unknown, val: unknown, path: PathSegments
   let p: number;
   while (++cursor < len) {
     step = path[cursor];
+    if (step === '__proto__' || step === 'constructor' || step === 'prototype') {
+      throw new Error('Prototype pollution attempt detected.');
+    }
     if (Array.isArray(it)) {
       if (step === '-' && cursor === end) {
         it.push(val);


### PR DESCRIPTION
### 📊 Metadata *

`json-ptr` is vulnerable to `Prototype Pollution`.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-json-ptr/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as _proto_, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```js
// poc.js
var {JsonPointer } = require("json-ptr")
var obj = {}
console.log("Before : " + obj.polluted);
JsonPointer.set(obj,'/__proto__/polluted','Yes! Its Polluted', true);
var obj1 ={}
console.log("After : " + obj1.polluted);
```

2. Execute the following commands in another terminal:

```bash
npm i json-ptr # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

![Captura de pantalla de 2020-10-18 13-00-01](https://user-images.githubusercontent.com/7505980/96364151-f40d7080-1141-11eb-9685-b621fac5cc0d.png)

Same result can be achieved with next poc, **the proposed fix also handles this case**:

```
var {JsonPointer } = require("./dist/")
var obj = {}
console.log("Before : " + obj.polluted);
JsonPointer.set(obj,'/constructor/prototype/polluted','Yes! Its Polluted', true);
var obj1 ={}
console.log("After : " + obj1.polluted);
```

### 🔥 Proof of Fix (PoF) *

After fix execution will block prototype pollution and throw an exception 

![Captura de pantalla de 2020-10-18 13-00-22](https://user-images.githubusercontent.com/7505980/96364156-f96abb00-1141-11eb-9945-5dd7f2a98a9a.png)

### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected