### PR TITLE
Security fix for Arbitrary Code Execution in json-ptr

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -148,6 +148,9 @@ export function compilePointerDereference(path: PathSegments): Dereference {
     return (it): unknown => it;
   }
   body = path.reduce((body, _, i) => {
+    if (/[\(|\)|\']/.test(path[i])){
+      throw new Error('Arbitrary code injection attempt detected.');
+    }
     return body + " && \n\ttypeof((it = it['" + replace(path[i] + '', '\\', '\\\\') + "'])) !== 'undefined'";
   }, "if (typeof(it) !== 'undefined'") as string;
   body = body + ') {\n\treturn it;\n }';

--- a/src/util.ts
+++ b/src/util.ts
@@ -148,7 +148,7 @@ export function compilePointerDereference(path: PathSegments): Dereference {
     return (it): unknown => it;
   }
   body = path.reduce((body, _, i) => {
-    if (/[\(|\)|\']/.test(path[i])){
+    if (/[\(|\)]/.test(path[i])){
       throw new Error('Arbitrary code injection attempt detected.');
     }
     return body + " && \n\ttypeof((it = it['" + replace(path[i] + '', '\\', '\\\\') + "'])) !== 'undefined'";

--- a/src/util.ts
+++ b/src/util.ts
@@ -148,10 +148,7 @@ export function compilePointerDereference(path: PathSegments): Dereference {
     return (it): unknown => it;
   }
   body = path.reduce((body, _, i) => {
-    if (/[\(|\)]/.test(path[i])){
-      throw new Error('Arbitrary code injection attempt detected.');
-    }
-    return body + " && \n\ttypeof((it = it['" + replace(path[i] + '', '\\', '\\\\') + "'])) !== 'undefined'";
+    return body + " && \n\ttypeof((it = it['" + path[i].replace('\\', '\\\\').replace('\'', '\\\'') + "'])) !== 'undefined'";
   }, "if (typeof(it) !== 'undefined'") as string;
   body = body + ') {\n\treturn it;\n }';
   // eslint-disable-next-line no-new-func

--- a/src/util.ts
+++ b/src/util.ts
@@ -148,7 +148,7 @@ export function compilePointerDereference(path: PathSegments): Dereference {
     return (it): unknown => it;
   }
   body = path.reduce((body, _, i) => {
-    return body + " && \n\ttypeof((it = it['" + path[i].replace('\\', '\\\\').replace('\'', '\\\'') + "'])) !== 'undefined'";
+    return body + " && \n\ttypeof((it = it['" + path[i].replace('\\', '\\\\').replace(/\'/g, '\\\'') + "'])) !== 'undefined'";
   }, "if (typeof(it) !== 'undefined'") as string;
   body = body + ') {\n\treturn it;\n }';
   // eslint-disable-next-line no-new-func


### PR DESCRIPTION
### 📊 Metadata *

``JsonPointer.get`` that is designed to get the target object's value at the pointer's location is vulnerable to arbitrary code injection and exection, mainly due to the lack of sanitizing for user's inputs of the pointer's location.

#### Bounty URL: https://www.huntr.dev/bounties/2-npm-json-ptr/

### ⚙️ Description *

Escape ``'`` to avoid the injection.

### 💻 Technical Description *

Use ``path[i].replace('\\', '\\\\').replace(/\'/g, '\\\'')`` to escape ``'`` to avoid the injection.

### 🐛 Proof of Concept (PoC) *
```
jptr=require('json-ptr');
JsonPointer=jptr.JsonPointer;
JsonPointer.get({}, '/aaa\'\]\)\) !== \'undefined\') \{return it;\}; console.log(\'HACKED\'); if((([\'a'); // HACKED
```

![image](https://user-images.githubusercontent.com/834641/112755616-fc80a600-9013-11eb-85c2-97906cbd424c.png)

### 🔥 Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/834641/112757077-afec9900-901a-11eb-89c6-344dfb2485a0.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/834641/112755720-97798000-9014-11eb-8ce0-2f41aa706c71.png)

